### PR TITLE
BUG: remove unsupported quast param

### DIFF
--- a/q2_assembly/plugin_setup.py
+++ b/q2_assembly/plugin_setup.py
@@ -191,8 +191,7 @@ plugin.visualizers.register_function(
         'threads': Int % Range(1, None),
         'k_mer_stats': Bool,
         'k_mer_size': Int % Range(1, None),
-        'contig_thresholds': List[Int % Range(0, None)],
-        'x_for_Nx': Int % Range(0, 100),
+        'contig_thresholds': List[Int % Range(0, None)]
     },
     input_descriptions={
         'contigs': 'Assembled contigs to be analyzed.',
@@ -207,9 +206,7 @@ plugin.visualizers.register_function(
                        'memory and time consumption on large genomes.',
         'k_mer_size': 'Size of k used in k-mer-stats. Default: 101.',
         'contig_thresholds': 'List of contig length thresholds. '
-                             'Default: 0,1000,5000,10000,25000,50000.',
-        'x_for_Nx': 'Value of "x" for Nx, Lx, etc. metrics reported '
-                    'in addition to N50, L50, etc. Default: 90.',
+                             'Default: 0,1000,5000,10000,25000,50000.'
     },
     name='Evaluate quality of the assembled contigs using metaQUAST.',
     description='This method uses metaQUAST to assess the quality of '

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -169,8 +169,7 @@ def evaluate_contigs(
         threads: int = None,
         k_mer_stats: bool = False,
         k_mer_size: int = None,
-        contig_thresholds: List[int] = None,
-        x_for_Nx: int = None
+        contig_thresholds: List[int] = None
 ):
 
     kwargs = {k: v for k, v in locals().items() if

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -61,6 +61,11 @@ class TestQuast(TestPluginBase):
         exp = ('--threads', '1')
         self.assertTupleEqual(obs, exp)
 
+    def test_process_quast_arg_threads_none(self):
+        obs = _process_quast_arg('threads', None)
+        exp = ('--threads', '1')
+        self.assertTupleEqual(obs, exp)
+
     @patch('subprocess.run')
     def test_evaluate_contigs_minimal(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path('contigs'), 'r')


### PR DESCRIPTION
The `x_for_Nx` parameter is only supported by QUAST >= 5.1.0rc1 and we are currently using 5.0.2.