### PR TITLE
FIX: enable multi-processing on Linux

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: isort
         files: ^(.+)(?<!\_version)\.py$
+        args: ["--profile", "black"]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, QIIME 2 development team.
+Copyright (c) 2023, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_assembly/__init__.py
+++ b/q2_assembly/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/_action_params.py
+++ b/q2_assembly/_action_params.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/_utils.py
+++ b/q2_assembly/_utils.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/__init__.py
+++ b/q2_assembly/bowtie2/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/indexing.py
+++ b/q2_assembly/bowtie2/indexing.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/mapping.py
+++ b/q2_assembly/bowtie2/mapping.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/tests/__init__.py
+++ b/q2_assembly/bowtie2/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/tests/test_indexing.py
+++ b/q2_assembly/bowtie2/tests/test_indexing.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/tests/test_mapping.py
+++ b/q2_assembly/bowtie2/tests/test_mapping.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/tests/test_utils.py
+++ b/q2_assembly/bowtie2/tests/test_utils.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/bowtie2/utils.py
+++ b/q2_assembly/bowtie2/utils.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/iss/__init__.py
+++ b/q2_assembly/iss/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/iss/tests/__init__.py
+++ b/q2_assembly/iss/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/megahit/__init__.py
+++ b/q2_assembly/megahit/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/megahit/megahit.py
+++ b/q2_assembly/megahit/megahit.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/megahit/tests/__init__.py
+++ b/q2_assembly/megahit/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/megahit/tests/test_megahit.py
+++ b/q2_assembly/megahit/tests/test_megahit.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/plugin_setup.py
+++ b/q2_assembly/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/quast/__init__.py
+++ b/q2_assembly/quast/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -55,11 +55,7 @@ def _process_quast_arg(arg_key, arg_val):
     """
     if isinstance(arg_val, bool) and arg_val:
         return [_construct_param(arg_key)]
-    elif (
-        arg_key == "threads"
-        and (not arg_val or arg_val > 1)
-        and platform.system() == "Darwin"
-    ):
+    elif arg_key == "threads" and arg_val > 1 and platform.system() == "Darwin":
         print(
             "Multiprocessing is currently not supported on macOS. Resetting "
             "number of threads to 1."

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -55,12 +55,8 @@ def _process_quast_arg(arg_key, arg_val):
     """
     if isinstance(arg_val, bool) and arg_val:
         return [_construct_param(arg_key)]
-    elif arg_key == "threads" and arg_val > 1 and platform.system() == "Darwin":
-        print(
-            "Multiprocessing is currently not supported on macOS. Resetting "
-            "number of threads to 1."
-        )
-        return [_construct_param(arg_key), "1"]
+    elif arg_key == "threads" and arg_val > 1 and platform.system() != "Linux":
+        raise ValueError("Multiprocessing is currently only supported on Linux.")
     elif not isinstance(arg_val, list):
         return [_construct_param(arg_key), str(arg_val)]
     else:

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -9,6 +9,7 @@
 import glob
 import json
 import os
+import platform
 import subprocess
 import tempfile
 from distutils.dir_util import copy_tree
@@ -54,10 +55,13 @@ def _process_quast_arg(arg_key, arg_val):
     """
     if isinstance(arg_val, bool) and arg_val:
         return [_construct_param(arg_key)]
-    elif arg_key == "threads" and (not arg_val or arg_val > 1):
-        # TODO: this needs to be fixed (to allow multiprocessing)
+    elif (
+        arg_key == "threads"
+        and (not arg_val or arg_val > 1)
+        and platform.system() == "Darwin"
+    ):
         print(
-            "Multiprocessing is currently not supported. Resetting "
+            "Multiprocessing is currently not supported on macOS. Resetting "
             "number of threads to 1."
         )
         return [_construct_param(arg_key), "1"]

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -56,6 +56,8 @@ def _process_quast_arg(arg_key, arg_val):
     if isinstance(arg_val, bool) and arg_val:
         return [_construct_param(arg_key)]
     elif arg_key == "threads" and arg_val > 1 and platform.system() != "Linux":
+        # This is a limitation in quast that is documented in this issue:
+        # https://github.com/ablab/quast/issues/175
         raise ValueError("Multiprocessing is currently only supported on Linux.")
     elif not isinstance(arg_val, list):
         return [_construct_param(arg_key), str(arg_val)]

--- a/q2_assembly/quast/tests/__init__.py
+++ b/q2_assembly/quast/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -49,15 +49,19 @@ class TestQuast(TestPluginBase):
 
     @patch("platform.system", return_value="Darwin")
     def test_process_quast_arg_threads_many_Darwin(self, p1):
-        obs = _process_quast_arg("threads", 6)
-        exp = ["--threads", "1"]
-        self.assertListEqual(obs, exp)
+        with self.assertRaisesRegex(ValueError, "only supported on Linux"):
+            _process_quast_arg("threads", 6)
 
     @patch("platform.system", return_value="Linux")
     def test_process_quast_arg_threads_many_Linux(self, p1):
         obs = _process_quast_arg("threads", 6)
         exp = ["--threads", "6"]
         self.assertListEqual(obs, exp)
+
+    @patch("platform.system", return_value="")
+    def test_process_quast_arg_threads_many_unknownOS(self, p1):
+        with self.assertRaisesRegex(ValueError, "only supported on Linux"):
+            _process_quast_arg("threads", 6)
 
     def test_process_quast_arg_threads_correct(self):
         obs = _process_quast_arg("threads", 1)

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -52,9 +52,16 @@ class TestQuast(TestPluginBase):
         exp = ["--threads", "1"]
         self.assertListEqual(obs, exp)
 
-    def test_process_quast_arg_threads_too_many(self):
+    @patch("platform.system", return_value="Darwin")
+    def test_process_quast_arg_threads_many_Darwin(self, p1):
         obs = _process_quast_arg("threads", 6)
         exp = ["--threads", "1"]
+        self.assertListEqual(obs, exp)
+
+    @patch("platform.system", return_value="Linux")
+    def test_process_quast_arg_threads_many_Linux(self, p1):
+        obs = _process_quast_arg("threads", 6)
+        exp = ["--threads", "6"]
         self.assertListEqual(obs, exp)
 
     def test_process_quast_arg_threads_correct(self):
@@ -238,11 +245,12 @@ class TestQuast(TestPluginBase):
                 common_args=["-m", "10", "-t", "1"],
             )
 
+    @patch("platform.system", return_value="Linux")
     @patch("q2_assembly.quast._evaluate_contigs", return_value=["sample1", "sample2"])
     @patch("q2_assembly.quast._fix_html_reports", return_value=None)
     @patch("q2templates.render")
     @patch("tempfile.TemporaryDirectory")
-    def test_evaluate_contigs_action_no_reads(self, p1, p2, p3, p4):
+    def test_evaluate_contigs_action_no_reads(self, p1, p2, p3, p4, p5):
         test_temp_dir = MockTempDir()
         os.mkdir(os.path.join(test_temp_dir.name, "results"))
         p1.return_value = test_temp_dir
@@ -262,7 +270,7 @@ class TestQuast(TestPluginBase):
             contigs,
             {},
             False,
-            ["--min-contig", "150", "--threads", "1", "--contig-thresholds", "10,20"],
+            ["--min-contig", "150", "--threads", "5", "--contig-thresholds", "10,20"],
         )
         p3.assert_called_once_with(os.path.join(test_temp_dir.name, "results"))
 

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -47,11 +47,6 @@ class TestQuast(TestPluginBase):
         exp = ["--k-list", "1,2,3"]
         self.assertListEqual(obs, exp)
 
-    def test_process_quast_arg_threads_not_set(self):
-        obs = _process_quast_arg("threads", None)
-        exp = ["--threads", "1"]
-        self.assertListEqual(obs, exp)
-
     @patch("platform.system", return_value="Darwin")
     def test_process_quast_arg_threads_many_Darwin(self, p1):
         obs = _process_quast_arg("threads", 6)

--- a/q2_assembly/spades/__init__.py
+++ b/q2_assembly/spades/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/spades/spades.py
+++ b/q2_assembly/spades/spades.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/spades/tests/__init__.py
+++ b/q2_assembly/spades/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/spades/tests/test_spades.py
+++ b/q2_assembly/spades/tests/test_spades.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/tests/__init__.py
+++ b/q2_assembly/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_assembly/tests/test_utils.py
+++ b/q2_assembly/tests/test_utils.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022, QIIME 2 development team.
+# Copyright (c) 2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
Closes #32.

Unfortunately, multiprocessing seems not to be working on macOS, hence the platform check. See https://github.com/ablab/quast/issues/175.