### PR TITLE
fix file name to sample id assumption

### DIFF
--- a/q2_assembly/_action_params.py
+++ b/q2_assembly/_action_params.py
@@ -124,7 +124,7 @@ quast_params = {
 quast_param_descriptions = {
     "min_contig": "Lower threshold for contig length. Default: 500.",
     "threads": "Maximum number of parallel jobs. Default: 1. "
-               "Currently disabled - only 1 CPU is supported.",
+               "Currently supported on Linux only.",
     "k_mer_stats": "Compute k-mer-based quality metrics (recommended for large "
                    "genomes). This may significantly increase memory and time "
                    "consumption on large genomes.",

--- a/q2_assembly/_utils.py
+++ b/q2_assembly/_utils.py
@@ -121,4 +121,3 @@ def _modify_links(fp: str):
 def _get_sample_from_path(fp):
     """Extracts sample name from a contig's file path."""
     return os.path.basename(fp.replace("_contigs.fa", ""))
-

--- a/q2_assembly/_utils.py
+++ b/q2_assembly/_utils.py
@@ -120,4 +120,5 @@ def _modify_links(fp: str):
 
 def _get_sample_from_path(fp):
     """Extracts sample name from a contig's file path."""
-    return os.path.basename(fp).split("_", maxsplit=1)[0]
+    return os.path.basename(fp.replace("_contigs.fa", ""))
+

--- a/q2_assembly/_utils.py
+++ b/q2_assembly/_utils.py
@@ -120,4 +120,4 @@ def _modify_links(fp: str):
 
 def _get_sample_from_path(fp):
     """Extracts sample name from a contig's file path."""
-    return os.path.basename(fp).rsplit('_contigs.fa', maxsplit=1)[0]
+    return os.path.basename(fp).rsplit("_contigs.fa", maxsplit=1)[0]

--- a/q2_assembly/_utils.py
+++ b/q2_assembly/_utils.py
@@ -120,4 +120,4 @@ def _modify_links(fp: str):
 
 def _get_sample_from_path(fp):
     """Extracts sample name from a contig's file path."""
-    return os.path.basename(fp.replace("_contigs.fa", ""))
+    return os.path.basename(fp).rsplit('_contigs.fa', maxsplit=1)[0]

--- a/q2_assembly/bowtie2/tests/test_utils.py
+++ b/q2_assembly/bowtie2/tests/test_utils.py
@@ -28,10 +28,18 @@ class TestBowtie2Utils(TestPluginBase):
         self.assertEqual(obs, exp)
 
     def test_get_subdir_from_path_contig_underscores(self):
-        self.assertEqual(_get_subdir_from_path("/path/to/dir/sample_1_contigs.fa"), "sample_1")
-        self.assertEqual(_get_subdir_from_path("/path/to/dir/sample1_contigs.fa"), "sample1")
-        self.assertEqual(_get_subdir_from_path("/path/to/dir/s_am-p_le_1_contigs.fa"), "s_am-p_le_1")
-        self.assertEqual(_get_subdir_from_path("/path/to/dir/_contigs.fa_contigs.fa"), "_contigs.fa")
+        self.assertEqual(
+            _get_subdir_from_path("/path/to/dir/sample_1_contigs.fa"), "sample_1"
+        )
+        self.assertEqual(
+            _get_subdir_from_path("/path/to/dir/sample1_contigs.fa"), "sample1"
+        )
+        self.assertEqual(
+            _get_subdir_from_path("/path/to/dir/s_am-p_le_1_contigs.fa"), "s_am-p_le_1"
+        )
+        self.assertEqual(
+            _get_subdir_from_path("/path/to/dir/_contigs.fa_contigs.fa"), "_contigs.fa"
+        )
 
     def test_get_subdir_from_path_mag(self):
         obs = _get_subdir_from_path("/path/to/dir/sample1/mag1.fa", "mags")

--- a/q2_assembly/bowtie2/tests/test_utils.py
+++ b/q2_assembly/bowtie2/tests/test_utils.py
@@ -28,9 +28,10 @@ class TestBowtie2Utils(TestPluginBase):
         self.assertEqual(obs, exp)
 
     def test_get_subdir_from_path_contig_underscores(self):
-        obs = _get_subdir_from_path("/path/to/dir/sample_1_contigs.fa")
-        exp = "sample_1"
-        self.assertEqual(obs, exp)
+        self.assertEqual(_get_subdir_from_path("/path/to/dir/sample_1_contigs.fa"), "sample_1")
+        self.assertEqual(_get_subdir_from_path("/path/to/dir/sample1_contigs.fa"), "sample1")
+        self.assertEqual(_get_subdir_from_path("/path/to/dir/s_am-p_le_1_contigs.fa"), "s_am-p_le_1")
+        self.assertEqual(_get_subdir_from_path("/path/to/dir/_contigs.fa_contigs.fa"), "_contigs.fa")
 
     def test_get_subdir_from_path_mag(self):
         obs = _get_subdir_from_path("/path/to/dir/sample1/mag1.fa", "mags")

--- a/q2_assembly/bowtie2/tests/test_utils.py
+++ b/q2_assembly/bowtie2/tests/test_utils.py
@@ -27,6 +27,11 @@ class TestBowtie2Utils(TestPluginBase):
         exp = "sample1"
         self.assertEqual(obs, exp)
 
+    def test_get_subdir_from_path_contig_underscores(self):
+        obs = _get_subdir_from_path("/path/to/dir/sample_1_contigs.fa")
+        exp = "sample_1"
+        self.assertEqual(obs, exp)
+
     def test_get_subdir_from_path_mag(self):
         obs = _get_subdir_from_path("/path/to/dir/sample1/mag1.fa", "mags")
         exp = "sample1/mag1"

--- a/q2_assembly/bowtie2/utils.py
+++ b/q2_assembly/bowtie2/utils.py
@@ -8,7 +8,7 @@
 
 import os
 
-from q2_assembly._utils import _construct_param
+from q2_assembly._utils import _construct_param, _get_sample_from_path
 
 
 def _process_bowtie2build_arg(arg_key, arg_val):
@@ -139,7 +139,8 @@ def _get_subdir_from_path(fp: str, input_type: str = "contigs"):
         subdir (str): Subdir to be created, based on the given input.
     """
     if input_type.lower() == "contigs":
-        return os.path.basename(fp.replace("_contigs.fa", ""))
+        return _get_sample_from_path(fp)
+        # return os.path.basename(fp.replace("_contigs.fa", ""))
     elif input_type.lower() == "mags":
         fpl = os.path.splitext(fp)
         return os.path.join(*fpl[0].split("/")[-2:])

--- a/q2_assembly/bowtie2/utils.py
+++ b/q2_assembly/bowtie2/utils.py
@@ -139,7 +139,7 @@ def _get_subdir_from_path(fp: str, input_type: str = "contigs"):
         subdir (str): Subdir to be created, based on the given input.
     """
     if input_type.lower() == "contigs":
-        return os.path.basename(fp.replace('_contigs.fa', ''))
+        return os.path.basename(fp.replace("_contigs.fa", ""))
     elif input_type.lower() == "mags":
         fpl = os.path.splitext(fp)
         return os.path.join(*fpl[0].split("/")[-2:])

--- a/q2_assembly/bowtie2/utils.py
+++ b/q2_assembly/bowtie2/utils.py
@@ -139,7 +139,7 @@ def _get_subdir_from_path(fp: str, input_type: str = "contigs"):
         subdir (str): Subdir to be created, based on the given input.
     """
     if input_type.lower() == "contigs":
-        return os.path.basename(fp).split("_", maxsplit=1)[0]
+        return os.path.basename(fp.replace('_contigs.fa', ''))
     elif input_type.lower() == "mags":
         fpl = os.path.splitext(fp)
         return os.path.join(*fpl[0].split("/")[-2:])

--- a/q2_assembly/tests/test_utils.py
+++ b/q2_assembly/tests/test_utils.py
@@ -20,6 +20,7 @@ from q2_assembly.quast.quast import _fix_html_reports
 
 from .._utils import (
     _construct_param,
+    _get_sample_from_path,
     _modify_links,
     _process_common_input_params,
     _remove_html_element,
@@ -118,6 +119,11 @@ class TestUtils(TestPluginBase):
             f"{self._tmp}/icarus_viewers/contig_size_viewer.html",
             f"{self._tmp}/expected/contig_size_viewer.html",
         )
+
+    def test_get_sample_from_path(self):
+        obs = _get_sample_from_path("test/path/sample_1_contigs.fa")
+        exp = "sample_1"
+        self.assertEqual(obs, exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates an out-dated parameter description (#36) and fixes an error in an assumption about how filenames map onto sample ids (#37). Note that the third commit in this PR fixes this assumption in a second location. That code should ultimately be updated to use the function that was fixed in the second commit, so this logic is centralized (and therefore consistent) throughout the codebase. 

Tests also need to be added for the fixed functionality. @misialq or @Keegan-Evans, any chance you could pull these changes and add the test? I have done local testing, and can confirm the that fix in the third commit allows index-contigs to complete for me. The fix in the second commit seems to be working - the job is running, but it's much further along that where it previously failed. 