### PR TITLE
update to install most recent working q2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install _q2-assembly_, follow the installation steps described below.
 
 ```shell
 mamba create -yn q2-shotgun \
-  -c https://packages.qiime2.org/qiime2/2022.8/tested \
+  -c https://packages.qiime2.org/qiime2/2022.11/tested \
   -c bioconda -c conda-forge -c default q2-assembly q2cli
 
 conda activate q2-shotgun


### PR DESCRIPTION
Tested with 2023.02 and got the following error from mamba:

```
$ mamba create -yn q2-shotgun \
>   -c https://packages.qiime2.org/qiime2/2023.2/tested \
>   -c bioconda -c conda-forge -c default q2-assembly q2cli
...
Encountered problems while solving:
  - nothing provides requested q2-assembly
```