### PR TITLE
FIX: correct indexing params spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
       - id: check-merge-conflict
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         files: ^(.+)(?<!\_version)\.py$

--- a/q2_assembly/_action_params.py
+++ b/q2_assembly/_action_params.py
@@ -184,7 +184,7 @@ bowtie2_indexing_params = {
     "verbose": Bool,
     "noauto": Bool,
     "packed": Bool,
-    "bmax": Int % Range(1, None) | Choices(["auto"]),
+    "bmax": Int % Range(1, None) | Str % Choices(["auto"]),
     "bmaxdivn": Int % Range(1, None),
     "dcv": Int % Range(1, None),
     "nodc": Bool,


### PR DESCRIPTION
This PR fixes specification of one of the indexing params in `_action_params.py` - missing `Str` is causing a `q2cli` error:
```
AttributeError: <class 'qiime2.core.type.grammar.PredicateExp'> object has no attribute 'duplicate'
```

Additionally, one of the pre-commit hooks is updated (isort).