### PR TITLE
PIN: relax bowtie2 pin to resolve community distro failures

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - quast
     - beautifulsoup4
     - biopython <=1.78
-    - bowtie2 ==2.4.4
+    - bowtie2 >=2.4.4
     - samtools
     - insilicoseq
     - megahit ==1.2.9


### PR DESCRIPTION
Hi all! Finally back in the states and already looking forward to our next in-person sprint week 😉 

In less fun news, it looks like our community distro builds are failing due to (big surprise) some dependency conflicts. In short, the bowtie2 version that's pinned in assembly is forcing some other dependency versions that are no longer compatible with the community distro. The more verbose explanation is below (from an internal cap lab thread with @ebolyen):

_q2-assembly currently uses an older bowtie2 (2.4.4 vs. 2.5.1), which pins tbb to a 2020 version, which pulls numba down to a particularly old version. The current q2-diversity includes a line which pins numba, to 0.56.4, which is unsolvable with tbb 2020. To be clear, the older resolution involves the defaults channel which is almost never a good sign, so it's not like it's quite working right as is._

I pulled down q2-assembly locally and relaxed bowtie2's version to a min pin (bowtie2 >=2.4.4) - the tests still pass locally, so it doesn't seem like this update to bowtie2 would cause any issues with the current code in q2-assembly. I think this should resolve the community distro failures, so was hoping this could be merged sometime before our next release in a few weeks. With that being said, please let me know if updating this would be problematic for any reason I may have overlooked!