### PR TITLE
Added handling for empty or None sample_names

### DIFF
--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -145,7 +145,6 @@ def generate_reads(
     if not sample_names:
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
-    
     if len(set(sample_names)) < len(sample_names):
         dupl = {str(x) for x in sample_names if sample_names.count(x) > 1}
         raise Exception(

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -145,6 +145,12 @@ def generate_reads(
     if not sample_names:
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
+        print (
+            'The "--p-sample-names" option was not provided. ' 
+            'Only one sample will be created with the prefix "sample".'
+            '\n'
+        )
+
     if len(set(sample_names)) < len(sample_names):
         dupl = {str(x) for x in sample_names if sample_names.count(x) > 1}
         raise Exception(

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -145,8 +145,8 @@ def generate_reads(
     if not sample_names:
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
-        print (
-            'The "--p-sample-names" option was not provided. ' 
+        print(
+            'The "--p-sample-names" option was not provided. '
             'Only one sample will be created with the prefix "sample".'
             '\n'
         )

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -146,8 +146,8 @@ def generate_reads(
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
         print(
-            "The --p-sample-names option was not provided."
-            "Only one sample will be created with the prefix sample."
+            "The \"--p-sample-names\" option was not provided."
+            "Only one sample will be created with the prefix \"sample\"."
             "\n"
         )
 

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -142,6 +142,10 @@ def generate_reads(
         )
         _locals["n_genomes"] = available_genomes - 1
 
+    if not sample_names:
+        # If it's empty or None, create a list with a default element "sample"
+        sample_names = ["sample"]
+    
     if len(set(sample_names)) < len(sample_names):
         dupl = {str(x) for x in sample_names if sample_names.count(x) > 1}
         raise Exception(

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -146,8 +146,8 @@ def generate_reads(
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
         print(
-            "The \"--p-sample-names\" option was not provided."
-            "Only one sample will be created with the prefix \"sample\"."
+            'The "--p-sample-names" option was not provided.'
+            'Only one sample will be created with the prefix "sample".'
             "\n"
         )
 

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -146,9 +146,9 @@ def generate_reads(
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
         print(
-            'The "--p-sample-names" option was not provided. '
-            'Only one sample will be created with the prefix "sample".'
-            '\n'
+            "The --p-sample-names option was not provided."
+            "Only one sample will be created with the prefix sample."
+            "\n"
         )
 
     if len(set(sample_names)) < len(sample_names):

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -146,7 +146,7 @@ def generate_reads(
         # If it's empty or None, create a list with a default element "sample"
         sample_names = ["sample"]
         print(
-            'The "--p-sample-names" option was not provided.'
+            'The "--p-sample-names" option was not provided. '
             'Only one sample will be created with the prefix "sample".'
             "\n"
         )

--- a/q2_assembly/iss/iss.py
+++ b/q2_assembly/iss/iss.py
@@ -94,6 +94,18 @@ def _abundances_to_biom(abundance_fps):
     )
 
 
+def _ensure_sample_names_exists(sample_names):
+    if not sample_names:
+        # If it's empty or None, create a list with a default element "sample"
+        sample_names = ["sample"]
+        print(
+            'The "--p-sample-names" option was not provided. '
+            'Only one sample will be created with the prefix "sample".'
+            "\n"
+        )
+    return sample_names
+
+
 # TODO: allow to input custom genomes and sample from those
 def generate_reads(
     genomes: DNAFASTAFormat = None,
@@ -142,14 +154,7 @@ def generate_reads(
         )
         _locals["n_genomes"] = available_genomes - 1
 
-    if not sample_names:
-        # If it's empty or None, create a list with a default element "sample"
-        sample_names = ["sample"]
-        print(
-            'The "--p-sample-names" option was not provided. '
-            'Only one sample will be created with the prefix "sample".'
-            "\n"
-        )
+    sample_names = _ensure_sample_names_exists(sample_names)
 
     if len(set(sample_names)) < len(sample_names):
         dupl = {str(x) for x in sample_names if sample_names.count(x) > 1}

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -99,31 +99,12 @@ class TestISS(TestPluginBase):
         exp = ["--k_bool"]
         self.assertListEqual(obs, exp)
 
-    """ CHANGE THIS BASED ON THE OTHE RMODULES
-    def mock_ensure_sample_names_exists(sample_names):
-        return ["sample"]
-
-    @patch("q2_assembly.iss._ensure_sample_names_exists")
-    def test_ensure_sample_names_exists(self, mock_ensure_sample_names_exists):
-        # Your test cases go here
-        sample_names = []
-        res = mock_ensure_sample_names_exists(sample_names)
-        self.assertNotEqual(sample_names, res)
-
-        sample_names = None
-        res = mock_ensure_sample_names_exists(sample_names)
-        self.assertNotEqual(sample_names, res)
-    """
-
-    @patch("builtins.print")  # Mock the 'print' function
+    @patch("builtins.print")
     def test_sample_names_empty(self, mock_print):
-        # Call the function with an empty list
         result = _ensure_sample_names_exists([])
 
-        # Check that the function returns the default sample name
         self.assertEqual(result, ["sample"])
 
-        # Check that the print function was called with the expected message
         mock_print.assert_called_once_with(
             'The "--p-sample-names" option was not provided. '
             'Only one sample will be created with the prefix "sample".'
@@ -131,10 +112,7 @@ class TestISS(TestPluginBase):
         )
 
     def test_sample_names_not_empty(self):
-        # Call the function with a non-empty list
         result = _ensure_sample_names_exists(["sample1", "sample2"])
-
-        # Check that the function returns the input list unchanged
         self.assertEqual(result, ["sample1", "sample2"])
 
     @patch("os.rename")

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -189,7 +189,7 @@ class TestISS(TestPluginBase):
         )
 
         def test_generate_reads_no_sample_names_provided(self):
-            generate_reads(n_genomes_ncbi=[1],ncbi=["bacteria"],n_reads=1)
+            generate_reads(n_genomes_ncbi=[1], ncbi=["bacteria"], n_reads=1)
 
 
 if __name__ == "__main__":

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -188,10 +188,9 @@ class TestISS(TestPluginBase):
             _table_to_dataframe(obs_abundances), _table_to_dataframe(exp_biom_table)
         )
 
-        # Test the scenario where the user does not provide an element for the sample_names list.
-        # The function generate_reads should handle this case without raising errors.
         def test_generate_reads_no_sample_names_provided(self):
             generate_reads(n_genomes_ncbi=[1],ncbi=["bacteria"],n_reads=1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -103,7 +103,7 @@ class TestISS(TestPluginBase):
     def test_sample_names_empty(self, mock_print):
         result = _ensure_sample_names_exists([])
 
-        self.assertEqual(result, ["sample"])
+        self.assertListEqual(result, ["sample"])
 
         mock_print.assert_called_once_with(
             'The "--p-sample-names" option was not provided. '
@@ -113,7 +113,7 @@ class TestISS(TestPluginBase):
 
     def test_sample_names_not_empty(self):
         result = _ensure_sample_names_exists(["sample1", "sample2"])
-        self.assertEqual(result, ["sample1", "sample2"])
+        self.assertListEqual(result, ["sample1", "sample2"])
 
     @patch("os.rename")
     def test_rename_reads(self, p):

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -23,6 +23,7 @@ from qiime2.plugin.testing import TestPluginBase
 
 from q2_assembly.iss.iss import (
     _abundances_to_biom,
+    _ensure_sample_names_exists,
     _generate_reads,
     _process_iss_arg,
     _rename_reads_files,
@@ -98,8 +99,43 @@ class TestISS(TestPluginBase):
         exp = ["--k_bool"]
         self.assertListEqual(obs, exp)
 
-    def test_generate_reads_no_sample_names_provided(self):
-        generate_reads(n_genomes_ncbi=[1], ncbi=["bacteria"], n_reads=1)
+    """ CHANGE THIS BASED ON THE OTHE RMODULES
+    def mock_ensure_sample_names_exists(sample_names):
+        return ["sample"]
+
+    @patch("q2_assembly.iss._ensure_sample_names_exists")
+    def test_ensure_sample_names_exists(self, mock_ensure_sample_names_exists):
+        # Your test cases go here
+        sample_names = []
+        res = mock_ensure_sample_names_exists(sample_names)
+        self.assertNotEqual(sample_names, res)
+
+        sample_names = None
+        res = mock_ensure_sample_names_exists(sample_names)
+        self.assertNotEqual(sample_names, res)
+    """
+
+    @patch("builtins.print")  # Mock the 'print' function
+    def test_sample_names_empty(self, mock_print):
+        # Call the function with an empty list
+        result = _ensure_sample_names_exists([])
+
+        # Check that the function returns the default sample name
+        self.assertEqual(result, ["sample"])
+
+        # Check that the print function was called with the expected message
+        mock_print.assert_called_once_with(
+            'The "--p-sample-names" option was not provided. '
+            'Only one sample will be created with the prefix "sample".'
+            "\n"
+        )
+
+    def test_sample_names_not_empty(self):
+        # Call the function with a non-empty list
+        result = _ensure_sample_names_exists(["sample1", "sample2"])
+
+        # Check that the function returns the input list unchanged
+        self.assertEqual(result, ["sample1", "sample2"])
 
     @patch("os.rename")
     def test_rename_reads(self, p):

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -98,6 +98,9 @@ class TestISS(TestPluginBase):
         exp = ["--k_bool"]
         self.assertListEqual(obs, exp)
 
+    def test_generate_reads_no_sample_names_provided(self):
+        generate_reads(n_genomes_ncbi=[1], ncbi=["bacteria"], n_reads=1)
+
     @patch("os.rename")
     def test_rename_reads(self, p):
         fp = self.get_data_path("reads")
@@ -187,9 +190,6 @@ class TestISS(TestPluginBase):
         pd.testing.assert_frame_equal(
             _table_to_dataframe(obs_abundances), _table_to_dataframe(exp_biom_table)
         )
-
-        def test_generate_reads_no_sample_names_provided(self):
-            generate_reads(n_genomes_ncbi=[1], ncbi=["bacteria"], n_reads=1)
 
 
 if __name__ == "__main__":

--- a/q2_assembly/iss/tests/test_iss.py
+++ b/q2_assembly/iss/tests/test_iss.py
@@ -188,6 +188,10 @@ class TestISS(TestPluginBase):
             _table_to_dataframe(obs_abundances), _table_to_dataframe(exp_biom_table)
         )
 
+        # Test the scenario where the user does not provide an element for the sample_names list.
+        # The function generate_reads should handle this case without raising errors.
+        def test_generate_reads_no_sample_names_provided(self):
+            generate_reads(n_genomes_ncbi=[1],ncbi=["bacteria"],n_reads=1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When the user does not provide anything for the sample-names option from the command line, the function is called without providing a value for sample_names and the sample_names variable will default to None. When we attempt to evaluate len(set(sample_names)), Python tries to create a set from sample_names, but since sample_names is None, it cannot create a set from a None object, hence the "NoneType object is not iterable" error. In case of an empty list we can add an element called "sample" as the default sample name and avoid that error.