### PR TITLE
adding more params to `evaluate_contigs`

### DIFF
--- a/q2_assembly/_action_params.py
+++ b/q2_assembly/_action_params.py
@@ -116,6 +116,11 @@ quast_params = {
     "k_mer_stats": Bool,
     "k_mer_size": Int % Range(1, None),
     "contig_thresholds": List[Int % Range(0, None)],
+    "memory_efficient": Bool,
+    "min_alignment": Int % Range(1, None),
+    "min_identity": Float % Range(80.0, 100.0),
+    "ambiguity_usage": Str % Choices(["none", "one", "all"]),
+    "ambiguity_score": Float % Range(0.8, 1.0),
 }
 # fmt: off
 quast_param_descriptions = {
@@ -127,6 +132,23 @@ quast_param_descriptions = {
                    "consumption on large genomes.",
     "k_mer_size": "Size of k used in k-mer-stats.",
     "contig_thresholds": "List of contig length thresholds.",
+    "memory_efficient": "Significantly reduce memory consumption for large "
+                        "genomes. Forces one separate thread per each "
+                        "assembly and each chromosome.",
+    "min_alignment": "Minimum length of alignment (in bp). Alignments "
+                     "shorter than this value will be filtered. Alignments "
+                     "shorter than 65 bp will be filtered regardless of this "
+                     "threshold.",
+    "min_identity": "Minimum percent identity considered as proper alignment."
+                    "Alignments with identities worse than this value will be "
+                    "filtered.",
+    "ambiguity_usage": "Way of processing equally good alignments of a contig "
+                       "that are likely repeats. \'none\', skips these "
+                       "alignments. \'one\', takes the very best alignment. "
+                       "\'all\', uses all alignments, but san cause a "
+                       "significant increase of # mismatches.",
+    "ambiguity_score": "Score for defining equally good alignments of a "
+                       "single contig (see --ambiguity-usage).",
 }
 # fmt: on
 iss_params = {

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -203,6 +203,11 @@ def evaluate_contigs(
     k_mer_stats: bool = False,
     k_mer_size: int = 101,
     contig_thresholds: List[int] = [0, 1000, 5000, 10000, 25000, 50000],
+    memory_efficient: bool = False,
+    min_alignment: int = 65,
+    min_identity: float = 90.0,
+    ambiguity_usage: str = 'one',
+    ambiguity_score: float = 0.99,
 ):
     kwargs = {
         k: v

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -145,6 +145,33 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
+    def test_evaluate_contigs_more_params_memory_efficient(self, p):
+        contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
+        obs_samples = _evaluate_contigs(
+            results_dir="some/dir",
+            contigs=contigs,
+            reads={},
+            paired=False,
+            references=None,
+            common_args=["-m", "10", "-t", "1", "--memory-efficient"],
+        )
+
+        exp_command = [
+            "metaquast.py",
+            "-o",
+            "some/dir",
+            "-m",
+            "10",
+            "-t",
+            "1",
+            "--memory-efficient",
+            os.path.join(str(contigs), "sample1_contigs.fa"),
+            os.path.join(str(contigs), "sample2_contigs.fa"),
+        ]
+        self.assertListEqual(obs_samples, ["sample1", "sample2"])
+        p.assert_called_once_with(exp_command, check=True)
+
+    @patch("subprocess.run")
     def test_evaluate_contigs_single_end(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
@@ -356,6 +383,14 @@ class TestQuast(TestPluginBase):
                 "101",
                 "--contig-thresholds",
                 "10,20",
+                "--min-alignment",
+                "65",
+                "--min-identity",
+                "90.0",
+                "--ambiguity-usage",
+                "one",
+                "--ambiguity-score",
+                "0.99"
             ],
         )
         p3.assert_called_once_with(os.path.join(test_temp_dir.name, "results"))
@@ -417,6 +452,14 @@ class TestQuast(TestPluginBase):
                 "101",
                 "--contig-thresholds",
                 "0,1000,5000,10000,25000,50000",
+                "--min-alignment",
+                "65",
+                "--min-identity",
+                "90.0",
+                "--ambiguity-usage",
+                "one",
+                "--ambiguity-score",
+                "0.99"
             ],
         )
         p3.assert_called_once_with(os.path.join(test_temp_dir.name, "results"))
@@ -478,6 +521,14 @@ class TestQuast(TestPluginBase):
                 "101",
                 "--contig-thresholds",
                 "0,1000,5000,10000,25000,50000",
+                "--min-alignment",
+                "65",
+                "--min-identity",
+                "90.0",
+                "--ambiguity-usage",
+                "one",
+                "--ambiguity-score",
+                "0.99"
             ],
         )
         p3.assert_called_once_with(os.path.join(test_temp_dir.name, "results"))


### PR DESCRIPTION
Initial attempt at resolving #34, at least in part. This PR adds the following parameters:

- `--p-memory-efficient`
- `--p-min-alignment`
- `--p-min-identity`
- `--p-ambiguity-usage`
- `--p-ambiguity-score`

Currently only simple test cases exist. I would very much like any input on suggestions for better tests. Hence why this PR is set as a Draft PR.