### PR TITLE
FIX: QUAST visualization button links should point to the correct set of files

### DIFF
--- a/q2_assembly/assets/quast/index.html
+++ b/q2_assembly/assets/quast/index.html
@@ -11,11 +11,11 @@
   <div class="row">
       <div class="col-lg-6">
           <div class="btn-group">
-              <a href="quast_data/combined_reference/report.pdf" class="btn btn-success"> Full report (pdf) </a>
-              <a href="quast_data/combined_reference/basic_stats/cumulative_plot.pdf" class="btn btn-default"> Cumulative plot </a>
-              <a href="quast_data/combined_reference/basic_stats/GC_content_plot.pdf" class="btn btn-default"> GC content plot </a>
-              <a href="quast_data/combined_reference/basic_stats/Nx_plot.pdf" class="btn btn-default"> Nx plot </a>
-              <a href="quast_data/combined_reference/report.tsv" class="btn btn-default"> Stats table (tsv) </a>
+              <a href="quast_data/report.pdf" class="btn btn-success"> Full report (pdf) </a>
+              <a href="quast_data/basic_stats/cumulative_plot.pdf" class="btn btn-default"> Cumulative plot </a>
+              <a href="quast_data/basic_stats/GC_content_plot.pdf" class="btn btn-default"> GC content plot </a>
+              <a href="quast_data/basic_stats/Nx_plot.pdf" class="btn btn-default"> Nx plot </a>
+              <a href="quast_data/report.tsv" class="btn btn-default"> Stats table (tsv) </a>
               <a href="quast_data/additional_reports.zip" class="btn btn-default"> Additional Reports (zip) </a>
           </div>
       </div>

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -278,10 +278,14 @@ def evaluate_contigs(
             "tabs": [
                 {"title": "QC report", "url": "index.html"},
                 {"title": "Contig browser", "url": "q2_icarus.html"},
-                {"title": "Krona charts", "url": "q2_krona_charts.html"},
             ],
             "samples": json.dumps(samples),
         }
+
+        if os.path.isdir(os.path.join(output_dir, "quast_data", "krona_charts")):
+            context["tabs"].append(
+                {"title": "Krona charts", "url": "q2_krona_charts.html"}
+            )
 
         index = os.path.join(TEMPLATES, "quast", "index.html")
         icarus = os.path.join(TEMPLATES, "quast", "q2_icarus.html")

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -403,7 +403,6 @@ class TestQuast(TestPluginBase):
             "tabs": [
                 {"title": "QC report", "url": "index.html"},
                 {"title": "Contig browser", "url": "q2_icarus.html"},
-                {"title": "Krona charts", "url": "q2_krona_charts.html"},
             ],
             "samples": json.dumps(["sample1", "sample2"]),
         }
@@ -473,7 +472,6 @@ class TestQuast(TestPluginBase):
             "tabs": [
                 {"title": "QC report", "url": "index.html"},
                 {"title": "Contig browser", "url": "q2_icarus.html"},
-                {"title": "Krona charts", "url": "q2_krona_charts.html"},
             ],
             "samples": json.dumps(["sample1", "sample2"]),
         }
@@ -543,7 +541,6 @@ class TestQuast(TestPluginBase):
             "tabs": [
                 {"title": "QC report", "url": "index.html"},
                 {"title": "Contig browser", "url": "q2_icarus.html"},
-                {"title": "Krona charts", "url": "q2_krona_charts.html"},
             ],
             "samples": json.dumps(["sample1", "sample2"]),
         }

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -499,6 +499,7 @@ class TestQuast(TestPluginBase):
     def test_evaluate_contigs_action_single_end(self, p1, p2, p3, p4):
         test_temp_dir = MockTempDir()
         os.mkdir(os.path.join(test_temp_dir.name, "results"))
+        os.mkdir(os.path.join(test_temp_dir.name, "results", "krona_charts"))
         p1.return_value = test_temp_dir
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = SingleLanePerSampleSingleEndFastqDirFmt(
@@ -557,6 +558,7 @@ class TestQuast(TestPluginBase):
             "tabs": [
                 {"title": "QC report", "url": "index.html"},
                 {"title": "Contig browser", "url": "q2_icarus.html"},
+                {"title": "Krona charts", "url": "q2_krona_charts.html"},
             ],
             "samples": json.dumps(["sample1", "sample2"]),
         }


### PR DESCRIPTION
This PR updates the links on the QUAST visualization buttons (they were pointing to the wrong set of files) and changes the visualization to only show the Krona tab when the actual data is present in the artifact.