### PR TITLE
PIN: adds pysam back into recipe file

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,9 +24,7 @@ requirements:
     - gridss
     - insilicoseq
     - megahit ==1.2.9
-    # commenting this out for testing purposes to see if the metagenome
-    # environment will solve without this package
-    # - pysam
+    - pysam {{ pysam }}
     - qiime2 {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*


### PR DESCRIPTION
This [bioconda PR](https://github.com/bioconda/bioconda-recipes/pull/47747) has been merged, so we are good to add pysam back into the recipe file - and we should get a new working metagenome distro that now includes this as a dependency. Previously commented out in [this PR](https://github.com/bokulich-lab/q2-assembly/pull/80) (for posterity).