### PR TITLE
FIX: pass BAM files to metaquast in the correct order

### DIFF
--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -124,12 +124,8 @@ def _evaluate_contigs(
         samples.append(_get_sample_from_path(fp))
 
     if mapped_reads:
-        dir_path = str(mapped_reads)
-        list_of_files = os.listdir(dir_path)
-        list_of_maps_paths = ",".join(
-            [os.path.join(dir_path, file) for file in list_of_files]
-        )
-        cmd.extend(["--bam", list_of_maps_paths])
+        bam_fps = sorted(glob.glob(os.path.join(str(mapped_reads), "*_alignment.bam")))
+        cmd.extend(["--bam", ",".join(bam_fps)])
     elif reads:
         rev_count = sum([True if x["rev"] else False for _, x in reads.items()])
         # TODO: this is a strange statement which most likely

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -334,10 +334,13 @@ def _create_tabular_results(results_dir: str, contig_thresholds: list) -> pd.Dat
     Returns:
         a Pandas dataframe with the tabular data.
     """
-    filename = "transposed_report.tsv"
-    filepath = os.path.join(results_dir, "combined_reference", filename)
+    subdir = os.path.join(results_dir, "combined_reference")
+    if os.path.isdir(subdir):
+        report_fp = os.path.join(subdir, "transposed_report.tsv")
+    else:
+        report_fp = os.path.join(results_dir, "transposed_report.tsv")
 
-    transposed_report = pd.read_csv(filepath, sep="\t", header=0)
+    transposed_report = pd.read_csv(report_fp, sep="\t", header=0)
     transposed_report_parsed = _parse_columns(transposed_report, contig_thresholds)
     return transposed_report_parsed
 

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -246,11 +246,6 @@ class TestQuast(TestPluginBase):
             common_args=["-m", "10", "-t", "1"],
         )
 
-        list_of_maps = os.listdir(str(alignment_map))
-        list_of_maps_paths = ",".join(
-            [os.path.join(str(alignment_map), file) for file in list_of_maps]
-        )
-
         exp_command = [
             "metaquast.py",
             "-o",
@@ -262,7 +257,8 @@ class TestQuast(TestPluginBase):
             os.path.join(str(contigs), "sample1_contigs.fa"),
             os.path.join(str(contigs), "sample2_contigs.fa"),
             "--bam",
-            list_of_maps_paths,
+            f"{os.path.join(str(alignment_map), 'sample1_alignment.bam')},"
+            f"{os.path.join(str(alignment_map), 'sample2_alignment.bam')}",
         ]
 
         self.assertListEqual(obs_samples, ["sample1", "sample2"])

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -211,10 +211,6 @@ class TestQuast(TestPluginBase):
             mapped_reads=alignment_map,
             common_args=["-m", "10", "-t", "1"],
         )
-        list_of_maps = os.listdir(str(alignment_map))
-        list_of_maps_paths = ",".join(
-            [os.path.join(str(alignment_map), file) for file in list_of_maps]
-        )
         exp_command = [
             "metaquast.py",
             "-o",
@@ -226,7 +222,8 @@ class TestQuast(TestPluginBase):
             os.path.join(str(contigs), "sample1_contigs.fa"),
             os.path.join(str(contigs), "sample2_contigs.fa"),
             "--bam",
-            list_of_maps_paths,
+            f"{os.path.join(str(alignment_map), 'sample1_alignment.bam')},"
+            f"{os.path.join(str(alignment_map), 'sample2_alignment.bam')}",
         ]
         self.assertListEqual(obs_samples, ["sample1", "sample2"])
         p.assert_called_once_with(exp_command, check=True)

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -734,9 +734,7 @@ class TestQuast(TestPluginBase):
     @patch("q2_assembly.quast._parse_columns")
     def test_create_tabular_results(self, p1, p2):
         temp_dir = MockTempDir()
-        report_path = os.path.join(
-            temp_dir.name, "combined_reference", "transposed_report.tsv"
-        )
+        report_path = os.path.join(temp_dir.name, "transposed_report.tsv")
         mock_df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         p2.return_value = mock_df
 

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -733,12 +733,26 @@ class TestQuast(TestPluginBase):
     @patch("pandas.read_csv")
     @patch("q2_assembly.quast._parse_columns")
     def test_create_tabular_results(self, p1, p2):
-        temp_dir = MockTempDir()
-        report_path = os.path.join(temp_dir.name, "transposed_report.tsv")
+        report_path = os.path.join(self.temp_dir.name, "transposed_report.tsv")
         mock_df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         p2.return_value = mock_df
 
-        _ = _create_tabular_results(temp_dir.name, [1000, 5000, 25000, 50000])
+        _ = _create_tabular_results(self.temp_dir.name, [1000, 5000, 25000, 50000])
+
+        p2.assert_called_once_with(report_path, sep="\t", header=0)
+        p1.assert_called_once_with(mock_df, [1000, 5000, 25000, 50000])
+
+    @patch("pandas.read_csv")
+    @patch("q2_assembly.quast._parse_columns")
+    def test_create_tabular_results_in_combined_subdir(self, p1, p2):
+        report_path = os.path.join(
+            self.temp_dir.name, "combined_reference", "transposed_report.tsv"
+        )
+        os.makedirs(os.path.join(self.temp_dir.name, "combined_reference"))
+        mock_df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        p2.return_value = mock_df
+
+        _ = _create_tabular_results(self.temp_dir.name, [1000, 5000, 25000, 50000])
 
         p2.assert_called_once_with(report_path, sep="\t", header=0)
         p1.assert_called_once_with(mock_df, [1000, 5000, 25000, 50000])


### PR DESCRIPTION
The BAM file paths passed to the metaQUAST command (if provided) have the wrong order - they need to be sorted so that the order matches the order of the contig files.