### PR TITLE
BUG: fix path in version file

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -9,7 +9,7 @@ jobs:
   ci:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
-      distro: metagenome
+      distro: moshpit
       recipe-path: 'conda-recipe'
       additional-reports-path: ./coverage.xml
       additional-reports-name: coverage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 QIIME 2 plugin for (meta)genome assembly.
 
 ## Installation
-_q2-assembly_ is available as part of the QIIME 2 metagenome distribution. For installation and usage instructions please consult the official [QIIME 2 documentation](https://docs.qiime2.org).
+_q2-assembly_ is available as part of the QIIME 2 moshpit distribution. For installation and usage instructions please consult the official [QIIME 2 documentation](https://docs.qiime2.org).
 
 ## Functionality
 This QIIME 2 plugin contains actions used to assemble (meta)genomes from short single/paired-end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.versioningit.write]
-file = "q2-assembly/_version.py"
+file = "q2_assembly/_version.py"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
This PR fixes a typo in the path where the version file will be written to when the python package is built. This ensures that the correct version will be present when running 'qiime info' via the cli.