### PR TITLE
PIN: template out SPAdes version req

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   - q2-demux {{ qiime2_epoch }}.*
   - samtools
   - shortuuid
-  - spades
+  - spades {{ spades }}
   build:
   - setuptools
   - versioningit


### PR DESCRIPTION
Hey @misialq! Now that we have the version pin for SPAdes under distributions, we can update the version requirement here to just pull from the templated version within the conda build environment. This should be ready to merge whenever but also isn't blocking anything - so whenever you get the chance 🙂 