### PR TITLE
MAINT: change input and output names for consistency

### DIFF
--- a/q2_assembly/_action_params.py
+++ b/q2_assembly/_action_params.py
@@ -104,8 +104,12 @@ spades_param_descriptions = {
     "only_assembler": "Runs only assembling (without read error correction).",
     "careful": "Tries to reduce number of mismatches and short indels.",
     "disable_rr": "Disables repeat resolution stage of assembling.",
-    "threads": "Number of threads.",
-    "memory": "RAM limit for SPAdes in Gb (terminates if exceeded).",
+    "threads": "Number of threads. By default SPAdes uses 512 Mb per thread for "
+               "buffers, which results in higher memory consumption. This can be "
+               "further affected by the --p-memory option.",
+    "memory": "RAM limit for SPAdes in Gb (terminates if exceeded). If a smaller "
+              "memory limit is set, SPAdes will use smaller buffers and thus less "
+              "memory per --p-threads.",
     "k": "List of k-mer sizes (must be odd and less than 128).",
     "cov_cutoff": "Coverage cutoff value (a positive float number, or 'auto', or "
                   "'off').",

--- a/q2_assembly/helpers/helpers.py
+++ b/q2_assembly/helpers/helpers.py
@@ -105,10 +105,10 @@ def collate_indices(indices: Bowtie2IndexDirFmt) -> Bowtie2IndexDirFmt:
     return collated_indices
 
 
-def collate_alignments(alignments: BAMDirFmt) -> BAMDirFmt:
+def collate_alignments(alignment_maps: BAMDirFmt) -> BAMDirFmt:
     collated_alignments = BAMDirFmt()
 
-    for alignment in alignments:
+    for alignment in alignment_maps:
         for _alignment in alignment.path.iterdir():
             filename = os.path.basename(_alignment)
             duplicate(_alignment, os.path.join(collated_alignments.path, filename))

--- a/q2_assembly/megahit/tests/test_megahit.py
+++ b/q2_assembly/megahit/tests/test_megahit.py
@@ -264,7 +264,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=False,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -283,7 +283,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=False,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -302,7 +302,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=True,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -322,7 +322,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=True,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -342,7 +342,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=True,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -362,7 +362,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         obs = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=True,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -382,7 +382,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         _ = _assemble_megahit(
-            seqs=input,
+            reads=input,
             presets="meta-sensitive",
             bubble_level=1,
             k_list=[1, 2],
@@ -418,7 +418,7 @@ class TestMegahit(TestPluginBase):
             "200",
         ]
         p1.assert_called_with(
-            seqs=input, coassemble=False, uuid_type="shortuuid", common_args=exp_args
+            reads=input, coassemble=False, uuid_type="shortuuid", common_args=exp_args
         )
 
     def test_assemble_megahit_parallel_paired(self):
@@ -453,7 +453,7 @@ class TestMegahit(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         _ = assemble_megahit_helper(
-            seqs=input,
+            reads=input,
             coassemble=False,
             uuid_type=uuid_type,
             common_args=self.test_params_list,

--- a/q2_assembly/plugin_setup.py
+++ b/q2_assembly/plugin_setup.py
@@ -72,10 +72,10 @@ P_coassemble, T_coassembled_seqs = TypeMap(
 
 plugin.pipelines.register_function(
     function=q2_assembly.megahit.assemble_megahit,
-    inputs={"seqs": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
+    inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**megahit_params, "coassemble": P_coassemble, **partition_params},
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"seqs": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
     parameter_descriptions={
         **megahit_param_descriptions,
         **partition_param_descriptions,
@@ -89,10 +89,10 @@ plugin.pipelines.register_function(
 
 plugin.methods.register_function(
     function=q2_assembly.megahit._assemble_megahit,
-    inputs={"seqs": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
+    inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**megahit_params, "coassemble": P_coassemble},  # megahit_params,
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"seqs": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
     parameter_descriptions=megahit_param_descriptions,
     output_descriptions={"contigs": "The resulting assembled contigs."},
     name="Assemble contigs using MEGAHIT.",
@@ -142,10 +142,10 @@ plugin.methods.register_function(
 
 plugin.methods.register_function(
     function=q2_assembly.spades.assemble_spades,
-    inputs={"seqs": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
+    inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**spades_params, "coassemble": P_coassemble},
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"seqs": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
     parameter_descriptions=spades_param_descriptions,
     output_descriptions={"contigs": "The resulting assembled contigs."},
     name="Assemble contigs using SPAdes.",
@@ -160,14 +160,14 @@ plugin.visualizers.register_function(
         "contigs": SampleData[Contigs],
         "reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality],
         "references": GenomeData[DNASequence],
-        "mapped_reads": SampleData[AlignmentMap],
+        "alignment_maps": SampleData[AlignmentMap],
     },
     parameters={**quast_params, "genomes_dir": Str},
     input_descriptions={
         "contigs": "Assembled contigs to be analyzed.",
         "reads": "Original single- or paired-end reads.",
         "references": "Reference genomes to align the assembled contigs against.",
-        "mapped_reads": "Reads-to-contigs alignment maps (alternative to 'reads')."
+        "alignment_maps": "Reads-to-contigs alignment maps (alternative to 'reads')."
         "directly.",
     },
     parameter_descriptions={
@@ -189,7 +189,7 @@ plugin.pipelines.register_function(
         "contigs": SampleData[Contigs],
         "reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality],
         "references": GenomeData[DNASequence],
-        "mapped_reads": SampleData[AlignmentMap],
+        "alignment_maps": SampleData[AlignmentMap],
     },
     parameters=quast_params,
     outputs=[
@@ -201,7 +201,7 @@ plugin.pipelines.register_function(
         "contigs": "Assembled contigs to be analyzed.",
         "reads": "Original single- or paired-end reads.",
         "references": "Reference genomes to align the assembled contigs against.",
-        "mapped_reads": "Reads-to-contigs alignment maps (alternative to 'reads')."
+        "alignment_maps": "Reads-to-contigs alignment maps (alternative to 'reads')."
         "directly.",
     },
     parameter_descriptions=quast_param_descriptions,
@@ -336,7 +336,7 @@ plugin.pipelines.register_function(
         "reads": SampleData[PairedEndSequencesWithQuality | SequencesWithQuality],
     },
     parameters={**bowtie2_mapping_params, **partition_params},
-    outputs=[("alignment_map", O_alignment)],
+    outputs=[("alignment_maps", O_alignment)],
     input_descriptions={
         "index": "Bowtie 2 indices generated for contigs/MAGs of interest.",
         "reads": "The paired- or single-end reads from which the contigs "
@@ -346,7 +346,7 @@ plugin.pipelines.register_function(
         **bowtie2_mapping_param_descriptions,
         **partition_param_descriptions,
     },
-    output_descriptions={"alignment_map": "Reads-to-contigs mapping."},
+    output_descriptions={"alignment_maps": "Reads-to-contigs mapping."},
     name="Map reads to contigs using Bowtie2.",
     description="This method uses Bowtie2 to map provided reads to "
     "respective contigs.",
@@ -360,14 +360,14 @@ plugin.methods.register_function(
         "reads": SampleData[PairedEndSequencesWithQuality | SequencesWithQuality],
     },
     parameters=bowtie2_mapping_params,
-    outputs=[("alignment_map", SampleData[AlignmentMap])],
+    outputs=[("alignment_maps", SampleData[AlignmentMap])],
     input_descriptions={
         "index": "Bowtie 2 indices generated for contigs of interest.",
         "reads": "The paired- or single-end reads from which the contigs "
         "were assembled.",
     },
     parameter_descriptions=bowtie2_mapping_param_descriptions,
-    output_descriptions={"alignment_map": "Reads-to-contigs mapping."},
+    output_descriptions={"alignment_maps": "Reads-to-contigs mapping."},
     name="Map reads to contigs using Bowtie2.",
     description="This method uses Bowtie2 to map provided reads to "
     "respective contigs.",
@@ -387,14 +387,14 @@ plugin.methods.register_function(
         "reads": SampleData[PairedEndSequencesWithQuality | SequencesWithQuality],
     },
     parameters=bowtie2_mapping_params,
-    outputs=[("alignment_map", O_map)],
+    outputs=[("alignment_maps", O_map)],
     input_descriptions={
         "index": "Bowtie 2 indices generated for MAGs of interest.",
         "reads": "The paired- or single-end reads from which the contigs "
         "were assembled.",
     },
     parameter_descriptions=bowtie2_mapping_param_descriptions,
-    output_descriptions={"alignment_map": "Reads-to-MAGs mapping."},
+    output_descriptions={"alignment_maps": "Reads-to-MAGs mapping."},
     name="Map reads to MAGs using Bowtie2.",
     description="This method uses Bowtie2 to map provided reads to "
     "the respective MAGs.",
@@ -409,12 +409,14 @@ I_maps, O_maps = TypeMap(
 )
 plugin.methods.register_function(
     function=q2_assembly.helpers.collate_alignments,
-    inputs={"alignments": List[I_maps]},
+    inputs={"alignment_maps": List[I_maps]},
     parameters={},
-    outputs=[("collated_alignments", O_maps)],
-    input_descriptions={"alignments": "A collection of alignments to be collated."},
+    outputs=[("collated_alignment_maps", O_maps)],
+    input_descriptions={
+        "alignment_maps": "A collection of alignment maps to be collated."
+    },
     output_descriptions={
-        "collated_alignments": "The alignemnts collated into one artifact."
+        "collated_alignment_maps": "The alignment maps collated into one artifact."
     },
     name="Map reads to contigs helper.",
     description="Not to be called directly. Used by map_reads.",

--- a/q2_assembly/plugin_setup.py
+++ b/q2_assembly/plugin_setup.py
@@ -75,7 +75,9 @@ plugin.pipelines.register_function(
     inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**megahit_params, "coassemble": P_coassemble, **partition_params},
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={
+        "reads": "The paired- or single-end sequences to be assembled."
+    },
     parameter_descriptions={
         **megahit_param_descriptions,
         **partition_param_descriptions,
@@ -92,7 +94,9 @@ plugin.methods.register_function(
     inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**megahit_params, "coassemble": P_coassemble},  # megahit_params,
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={
+        "reads": "The paired- or single-end sequences to be assembled."
+    },
     parameter_descriptions=megahit_param_descriptions,
     output_descriptions={"contigs": "The resulting assembled contigs."},
     name="Assemble contigs using MEGAHIT.",
@@ -145,7 +149,9 @@ plugin.methods.register_function(
     inputs={"reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality]},
     parameters={**spades_params, "coassemble": P_coassemble},
     outputs=[("contigs", T_coassembled_seqs)],
-    input_descriptions={"reads": "The paired- or single-end sequences to be assembled."},
+    input_descriptions={
+        "reads": "The paired- or single-end sequences to be assembled."
+    },
     parameter_descriptions=spades_param_descriptions,
     output_descriptions={"contigs": "The resulting assembled contigs."},
     name="Assemble contigs using SPAdes.",

--- a/q2_assembly/plugin_setup.py
+++ b/q2_assembly/plugin_setup.py
@@ -185,12 +185,12 @@ plugin.visualizers.register_function(
     description="This method visualizes the results of metaQUAST after "
     "assessing the quality of assembled metagenomes. WARNING: This action "
     "should not be used as a standalone-action. It is designed to be called "
-    "by the evaluate-contigs action!",
+    "by the evaluate-quast action!",
     citations=[citations["Mikheenko2016"], citations["Mikheenko2018"]],
 )
 
 plugin.pipelines.register_function(
-    function=q2_assembly.quast.evaluate_contigs,
+    function=q2_assembly.quast.evaluate_quast,
     inputs={
         "contigs": SampleData[Contigs],
         "reads": SampleData[SequencesWithQuality | PairedEndSequencesWithQuality],

--- a/q2_assembly/quast/__init__.py
+++ b/q2_assembly/quast/__init__.py
@@ -6,6 +6,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .quast import evaluate_contigs
+from .quast import evaluate_quast
 
-__all__ = ["evaluate_contigs"]
+__all__ = ["evaluate_quast"]

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -92,7 +92,7 @@ def _evaluate_contigs(
     reads: dict,
     paired: bool,
     references: GenomeSequencesDirectoryFormat,
-    mapped_reads: BAMDirFmt,
+    alignment_maps: BAMDirFmt,
     common_args: list,
 ) -> List[str]:
     """Runs the contig assembly QC using QUAST.
@@ -105,7 +105,7 @@ def _evaluate_contigs(
         reads (dict): Dictionary containing mapping of samples to their
             forward and reverse reads, e.g.:
             {'sample1': {'fwd': '/path/to/reads', 'rev': '/path/to/reads'}}.
-        mapped_reads (BAMDirFmt): Mapping of reads to contigs
+        alignment_maps (BAMDirFmt): Mapping of reads to contigs
         common_args (list): List of common flags and their values for
             the QUAST command.
 
@@ -119,7 +119,7 @@ def _evaluate_contigs(
     cmd.extend(common_args)
     samples = []
 
-    if reads and mapped_reads:
+    if reads and alignment_maps:
         reads = None
         print("Both reads and mapped reads are provided. Reads will be ignored.")
 
@@ -127,8 +127,8 @@ def _evaluate_contigs(
         cmd.append(fp)
         samples.append(_get_sample_from_path(fp))
 
-    if mapped_reads:
-        bam_fps = sorted(glob.glob(os.path.join(str(mapped_reads), "*_alignment.bam")))
+    if alignment_maps:
+        bam_fps = sorted(glob.glob(os.path.join(str(alignment_maps), "*_alignment.bam")))
         cmd.extend(["--bam", ",".join(bam_fps)])
     elif reads:
         rev_count = sum([True if x["rev"] else False for _, x in reads.items()])
@@ -248,7 +248,7 @@ def _visualize_quast(
     ] = None,
     references: GenomeSequencesDirectoryFormat = None,
     genomes_dir: str = None,
-    mapped_reads: BAMDirFmt = None,
+    alignment_maps: BAMDirFmt = None,
 ) -> None:
     kwargs = {
         k: v
@@ -259,7 +259,7 @@ def _visualize_quast(
             "contigs",
             "reads",
             "references",
-            "mapped_reads",
+            "alignment_maps",
             "ctx",
             "genomes_dir",
         ]
@@ -290,7 +290,7 @@ def _visualize_quast(
             reads_fps,
             paired,
             references,
-            mapped_reads,
+            alignment_maps,
             common_args,
         )
 
@@ -373,7 +373,7 @@ def evaluate_contigs(
     contigs,
     reads=None,
     references=None,
-    mapped_reads=None,
+    alignment_maps=None,
     min_contig=500,
     threads=1,
     k_mer_stats=False,

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -128,7 +128,9 @@ def _evaluate_contigs(
         samples.append(_get_sample_from_path(fp))
 
     if alignment_maps:
-        bam_fps = sorted(glob.glob(os.path.join(str(alignment_maps), "*_alignment.bam")))
+        bam_fps = sorted(
+            glob.glob(os.path.join(str(alignment_maps), "*_alignment.bam"))
+        )
         cmd.extend(["--bam", ",".join(bam_fps)])
     elif reads:
         rev_count = sum([True if x["rev"] else False for _, x in reads.items()])

--- a/q2_assembly/quast/quast.py
+++ b/q2_assembly/quast/quast.py
@@ -86,7 +86,7 @@ def _split_reference(ref: DNAFASTAFormat, all_refs_dir: str) -> List[str]:
     return all_seq_fps
 
 
-def _evaluate_contigs(
+def _evaluate_quast(
     results_dir: str,
     contigs: ContigSequencesDirFmt,
     reads: dict,
@@ -286,7 +286,7 @@ def _visualize_quast(
         results_dir = os.path.join(tmp, "results")
 
         # run quast
-        samples = _evaluate_contigs(
+        samples = _evaluate_quast(
             results_dir,
             contigs,
             reads_fps,
@@ -369,7 +369,7 @@ def _create_tabular_results(results_dir: str, contig_thresholds: list) -> pd.Dat
     return transposed_report_parsed
 
 
-def evaluate_contigs(
+def evaluate_quast(
     # TODO: expose more parameters
     ctx,
     contigs,

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -34,14 +34,14 @@ from qiime2.sdk import Context
 
 from ..quast import (
     _create_tabular_results,
-    _evaluate_contigs,
+    _evaluate_quast,
     _move_references,
     _process_quast_arg,
     _split_reference,
     _visualize_quast,
     _zip_additional_reports,
     _zip_dir,
-    evaluate_contigs,
+    evaluate_quast,
 )
 
 
@@ -123,9 +123,9 @@ class TestQuast(TestPluginBase):
         )
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_minimal(self, p):
+    def test_evaluate_quast_minimal(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads={},
@@ -148,9 +148,9 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_more_params(self, p):
+    def test_evaluate_quast_more_params(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads={},
@@ -175,9 +175,9 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_more_params_memory_efficient(self, p):
+    def test_evaluate_quast_more_params_memory_efficient(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads={},
@@ -203,10 +203,10 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_with_map(self, p):
+    def test_evaluate_quast_with_map(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         alignment_maps = BAMDirFmt(self.get_data_path("alignment_map"), "r")
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads=None,
@@ -233,14 +233,14 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_with_map_and_reads(self, p):
+    def test_evaluate_quast_with_map_and_reads(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         alignment_maps = BAMDirFmt(self.get_data_path("alignment_map"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": None},
             "sample2": {"fwd": "path/to/s2fwd", "rev": None},
         }
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads=reads,
@@ -269,13 +269,13 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_single_end(self, p):
+    def test_evaluate_quast_single_end(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": None},
             "sample2": {"fwd": "path/to/s2fwd", "rev": None},
         }
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads=reads,
@@ -304,13 +304,13 @@ class TestQuast(TestPluginBase):
         p.assert_called_once_with(exp_command, check=True)
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_paired_end(self, p):
+    def test_evaluate_quast_paired_end(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": "path/to/s1rev"},
             "sample2": {"fwd": "path/to/s2fwd", "rev": "path/to/s2rev"},
         }
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads=reads,
@@ -342,7 +342,7 @@ class TestQuast(TestPluginBase):
         self.assertListEqual(obs_samples, ["sample1", "sample2"])
         p.assert_called_once_with(exp_command, check=True)
 
-    def test_evaluate_contigs_missing_rev_reads(self):
+    def test_evaluate_quast_missing_rev_reads(self):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": "path/to/s1rev"},
@@ -350,7 +350,7 @@ class TestQuast(TestPluginBase):
         with self.assertRaisesRegex(
             Exception, r".*reverse reads \(1\) does not match.*contig files \(2\).*"
         ):
-            _ = _evaluate_contigs(
+            _ = _evaluate_quast(
                 results_dir="some/dir",
                 contigs=contigs,
                 reads=reads,
@@ -360,7 +360,7 @@ class TestQuast(TestPluginBase):
                 common_args=["-m", "10", "-t", "1"],
             )
 
-    def test_evaluate_contigs_non_matching_samples(self):
+    def test_evaluate_quast_non_matching_samples(self):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": "path/to/s1rev"},
@@ -369,7 +369,7 @@ class TestQuast(TestPluginBase):
         with self.assertRaisesRegex(
             Exception, "Some samples are missing from the reads file."
         ):
-            _ = _evaluate_contigs(
+            _ = _evaluate_quast(
                 results_dir="some/dir",
                 contigs=contigs,
                 reads=reads,
@@ -382,7 +382,7 @@ class TestQuast(TestPluginBase):
     @patch(
         "subprocess.run", side_effect=CalledProcessError(returncode=123, cmd="some cmd")
     )
-    def test_evaluate_contigs_with_error(self, p):
+    def test_evaluate_quast_with_error(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": "path/to/s1rev"},
@@ -391,7 +391,7 @@ class TestQuast(TestPluginBase):
         with self.assertRaisesRegex(
             Exception, r"An error.*while running QUAST.*code 123"
         ):
-            _ = _evaluate_contigs(
+            _ = _evaluate_quast(
                 results_dir="some/dir",
                 contigs=contigs,
                 reads=reads,
@@ -402,7 +402,7 @@ class TestQuast(TestPluginBase):
             )
 
     @patch("subprocess.run")
-    def test_evaluate_contigs_with_refs(self, p1):
+    def test_evaluate_quast_with_refs(self, p1):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
         refs = GenomeSequencesDirectoryFormat(self.get_data_path("references"), "r")
 
@@ -411,7 +411,7 @@ class TestQuast(TestPluginBase):
             os.path.join(str(refs.path), "ref2.fasta"),
         ]
 
-        obs_samples = _evaluate_contigs(
+        obs_samples = _evaluate_quast(
             results_dir="some/dir",
             contigs=contigs,
             reads={},
@@ -439,7 +439,7 @@ class TestQuast(TestPluginBase):
 
     @patch("q2_assembly.quast._create_tabular_results")
     @patch("platform.system", return_value="Linux")
-    @patch("q2_assembly.quast._evaluate_contigs", return_value=["sample1", "sample2"])
+    @patch("q2_assembly.quast._evaluate_quast", return_value=["sample1", "sample2"])
     @patch("q2_assembly.quast._fix_html_reports", return_value=None)
     @patch("q2templates.render")
     @patch("tempfile.TemporaryDirectory")
@@ -501,7 +501,7 @@ class TestQuast(TestPluginBase):
         p2.assert_called_once_with(ANY, self._tmp, context=exp_context)
 
     @patch("q2_assembly.quast._create_tabular_results")
-    @patch("q2_assembly.quast._evaluate_contigs", return_value=["sample1", "sample2"])
+    @patch("q2_assembly.quast._evaluate_quast", return_value=["sample1", "sample2"])
     @patch("q2_assembly.quast._fix_html_reports", return_value=None)
     @patch("q2templates.render")
     @patch("tempfile.TemporaryDirectory")
@@ -578,7 +578,7 @@ class TestQuast(TestPluginBase):
         p2.assert_called_once_with(ANY, self._tmp, context=exp_context)
 
     @patch("q2_assembly.quast._create_tabular_results")
-    @patch("q2_assembly.quast._evaluate_contigs", return_value=["sample1", "sample2"])
+    @patch("q2_assembly.quast._evaluate_quast", return_value=["sample1", "sample2"])
     @patch("q2_assembly.quast._fix_html_reports", return_value=None)
     @patch("q2templates.render")
     @patch("tempfile.TemporaryDirectory")
@@ -653,11 +653,11 @@ class TestQuast(TestPluginBase):
         p2.assert_called_once_with(ANY, self._tmp, context=exp_context)
 
     @patch("q2_assembly.quast._create_tabular_results")
-    @patch("q2_assembly.quast._evaluate_contigs", return_value=["sample1", "sample2"])
+    @patch("q2_assembly.quast._evaluate_quast", return_value=["sample1", "sample2"])
     @patch("q2_assembly.quast._fix_html_reports", return_value=None)
     @patch("q2templates.render")
     @patch("tempfile.TemporaryDirectory")
-    def test_evaluate_contigs_action_paired_end_no_icarus(self, p1, p2, p3, p4, p5):
+    def test_evaluate_quast_action_paired_end_no_icarus(self, p1, p2, p3, p4, p5):
         test_temp_dir = MockTempDir()
         os.mkdir(os.path.join(test_temp_dir.name, "results"))
         p1.return_value = test_temp_dir
@@ -752,7 +752,7 @@ class TestQuast(TestPluginBase):
         p2.assert_called_once_with(report_path, sep="\t", header=0)
         p1.assert_called_once_with(mock_df, [1000, 5000, 25000, 50000])
 
-    def test_evaluate_contigs_pipeline_with_refs(self):
+    def test_evaluate_quast_pipeline_with_refs(self):
         def _copy_references(refs_dir, tmp):
             new_refs_dir = os.path.join(tmp, "vis_files", "quast_downloaded_references")
             os.makedirs(new_refs_dir, exist_ok=True)
@@ -775,7 +775,7 @@ class TestQuast(TestPluginBase):
             _copy_references(refs_dir, tmp)
 
             refs = Artifact.import_data("GenomeData[DNASequence]", refs_dir)
-            tab_report, _, _ = evaluate_contigs(
+            tab_report, _, _ = evaluate_quast(
                 ctx=mock_ctx, contigs=contigs, references=refs
             )
             make_artifact.assert_called_once_with(
@@ -810,7 +810,7 @@ class TestQuast(TestPluginBase):
             dst=os.path.join(dst_dir, "quast_results.tsv"),
         )
 
-    def test_evaluate_contigs_pipeline_no_refs_normal(self):
+    def test_evaluate_quast_pipeline_no_refs_normal(self):
         contigs = Artifact.import_data(
             "SampleData[Contigs]", self.get_data_path("contigs")
         )
@@ -829,7 +829,7 @@ class TestQuast(TestPluginBase):
                         path=self.get_data_path("references"), mode="r"
                     )
                 )
-                tab_report, _, _ = evaluate_contigs(ctx=mock_ctx, contigs=contigs)
+                tab_report, _, _ = evaluate_quast(ctx=mock_ctx, contigs=contigs)
                 make_artifact.assert_has_calls(
                     [
                         call("QUASTResults", self.assert_is_dataframe((2, 43))),
@@ -841,7 +841,7 @@ class TestQuast(TestPluginBase):
         self.assertEqual(action.call_args[0][0], contigs)
         export_data.assert_called_once_with(os.path.join(tmp, "vis_files"))
 
-    def test_evaluate_contigs_pipeline_no_refs_no_downloaded_genomes(self):
+    def test_evaluate_quast_pipeline_no_refs_no_downloaded_genomes(self):
         contigs = Artifact.import_data(
             "SampleData[Contigs]", self.get_data_path("contigs")
         )
@@ -860,7 +860,7 @@ class TestQuast(TestPluginBase):
                     MockGenomeSequencesDirectoryFormat.return_value = (
                         GenomeSequencesDirectoryFormat()
                     )
-                    tab_report, _, _ = evaluate_contigs(ctx=mock_ctx, contigs=contigs)
+                    tab_report, _, _ = evaluate_quast(ctx=mock_ctx, contigs=contigs)
                     make_artifact.assert_has_calls(
                         [
                             call(
@@ -881,7 +881,7 @@ class TestQuast(TestPluginBase):
             self.assertEqual(action.call_args[0][0], contigs)
             export_data.assert_called_once_with(os.path.join(tmp, "vis_files"))
 
-    def test_evaluate_contigs_pipeline_no_refs_corrupt_files(self):
+    def test_evaluate_quast_pipeline_no_refs_corrupt_files(self):
         contigs = Artifact.import_data(
             "SampleData[Contigs]", self.get_data_path("contigs")
         )
@@ -911,7 +911,7 @@ class TestQuast(TestPluginBase):
                         GenomeSequencesDirectoryFormat(),
                     ]
 
-                    tab_report, _, _ = evaluate_contigs(ctx=mock_ctx, contigs=contigs)
+                    tab_report, _, _ = evaluate_quast(ctx=mock_ctx, contigs=contigs)
 
                     self.assertRaises(ValidationError)
                     self.assertTrue(

--- a/q2_assembly/quast/tests/test_quast.py
+++ b/q2_assembly/quast/tests/test_quast.py
@@ -131,7 +131,7 @@ class TestQuast(TestPluginBase):
             reads={},
             paired=False,
             references=None,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-t", "1"],
         )
 
@@ -156,7 +156,7 @@ class TestQuast(TestPluginBase):
             reads={},
             paired=False,
             references=None,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-m", "10", "-t", "1"],
         )
 
@@ -183,7 +183,7 @@ class TestQuast(TestPluginBase):
             reads={},
             paired=False,
             references=None,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-m", "10", "-t", "1", "--memory-efficient"],
         )
 
@@ -205,14 +205,14 @@ class TestQuast(TestPluginBase):
     @patch("subprocess.run")
     def test_evaluate_contigs_with_map(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
-        alignment_map = BAMDirFmt(self.get_data_path("alignment_map"), "r")
+        alignment_maps = BAMDirFmt(self.get_data_path("alignment_map"), "r")
         obs_samples = _evaluate_contigs(
             results_dir="some/dir",
             contigs=contigs,
             reads=None,
             paired=False,
             references=None,
-            mapped_reads=alignment_map,
+            alignment_maps=alignment_maps,
             common_args=["-m", "10", "-t", "1"],
         )
         exp_command = [
@@ -226,8 +226,8 @@ class TestQuast(TestPluginBase):
             os.path.join(str(contigs), "sample1_contigs.fa"),
             os.path.join(str(contigs), "sample2_contigs.fa"),
             "--bam",
-            f"{os.path.join(str(alignment_map), 'sample1_alignment.bam')},"
-            f"{os.path.join(str(alignment_map), 'sample2_alignment.bam')}",
+            f"{os.path.join(str(alignment_maps), 'sample1_alignment.bam')},"
+            f"{os.path.join(str(alignment_maps), 'sample2_alignment.bam')}",
         ]
         self.assertListEqual(obs_samples, ["sample1", "sample2"])
         p.assert_called_once_with(exp_command, check=True)
@@ -235,7 +235,7 @@ class TestQuast(TestPluginBase):
     @patch("subprocess.run")
     def test_evaluate_contigs_with_map_and_reads(self, p):
         contigs = ContigSequencesDirFmt(self.get_data_path("contigs"), "r")
-        alignment_map = BAMDirFmt(self.get_data_path("alignment_map"), "r")
+        alignment_maps = BAMDirFmt(self.get_data_path("alignment_map"), "r")
         reads = {
             "sample1": {"fwd": "path/to/s1fwd", "rev": None},
             "sample2": {"fwd": "path/to/s2fwd", "rev": None},
@@ -246,7 +246,7 @@ class TestQuast(TestPluginBase):
             reads=reads,
             paired=False,
             references=None,
-            mapped_reads=alignment_map,
+            alignment_maps=alignment_maps,
             common_args=["-m", "10", "-t", "1"],
         )
 
@@ -261,8 +261,8 @@ class TestQuast(TestPluginBase):
             os.path.join(str(contigs), "sample1_contigs.fa"),
             os.path.join(str(contigs), "sample2_contigs.fa"),
             "--bam",
-            f"{os.path.join(str(alignment_map), 'sample1_alignment.bam')},"
-            f"{os.path.join(str(alignment_map), 'sample2_alignment.bam')}",
+            f"{os.path.join(str(alignment_maps), 'sample1_alignment.bam')},"
+            f"{os.path.join(str(alignment_maps), 'sample2_alignment.bam')}",
         ]
 
         self.assertListEqual(obs_samples, ["sample1", "sample2"])
@@ -281,7 +281,7 @@ class TestQuast(TestPluginBase):
             reads=reads,
             paired=False,
             references=None,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-m", "10", "-t", "1"],
         )
 
@@ -316,7 +316,7 @@ class TestQuast(TestPluginBase):
             reads=reads,
             paired=True,
             references=None,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-m", "10", "-t", "1"],
         )
 
@@ -356,7 +356,7 @@ class TestQuast(TestPluginBase):
                 reads=reads,
                 paired=True,
                 references=None,
-                mapped_reads=None,
+                alignment_maps=None,
                 common_args=["-m", "10", "-t", "1"],
             )
 
@@ -375,7 +375,7 @@ class TestQuast(TestPluginBase):
                 reads=reads,
                 paired=True,
                 references=None,
-                mapped_reads=None,
+                alignment_maps=None,
                 common_args=["-m", "10", "-t", "1"],
             )
 
@@ -397,7 +397,7 @@ class TestQuast(TestPluginBase):
                 reads=reads,
                 paired=True,
                 references=None,
-                mapped_reads=None,
+                alignment_maps=None,
                 common_args=["-m", "10", "-t", "1"],
             )
 
@@ -417,7 +417,7 @@ class TestQuast(TestPluginBase):
             reads={},
             paired=False,
             references=refs,
-            mapped_reads=None,
+            alignment_maps=None,
             common_args=["-t", "1"],
         )
 

--- a/q2_assembly/spades/spades.py
+++ b/q2_assembly/spades/spades.py
@@ -97,7 +97,7 @@ def _process_sample(sample, fwd, rev, common_args, out):
 
 
 def _assemble_spades(
-    seqs, meta, common_args, uuid_type, coassemble=False
+    reads, meta, common_args, uuid_type, coassemble=False
 ) -> ContigSequencesDirFmt:
     """Runs the assembly for all available samples.
 
@@ -105,7 +105,7 @@ def _assemble_spades(
     be adjusted accordingly.
 
     Args:
-        seqs: Sequences to be processed.
+        reads: Sequences to be processed.
         meta: True if it is a metagenomic assembly.
         common_args: List of common flags and their values for
             the metaSPAdes command.
@@ -118,12 +118,12 @@ def _assemble_spades(
 
     """
 
-    paired = isinstance(seqs, SingleLanePerSamplePairedEndFastqDirFmt)
+    paired = isinstance(reads, SingleLanePerSamplePairedEndFastqDirFmt)
     if not paired and meta:
         raise NotImplementedError(
             'SPAdes v3.15.2 in "meta" mode supports only ' "paired-end reads."
         )
-    manifest = seqs.manifest.view(pd.DataFrame)
+    manifest = reads.manifest.view(pd.DataFrame)
     result = ContigSequencesDirFmt()
 
     if coassemble:
@@ -167,7 +167,7 @@ def _assemble_spades(
 
 
 def assemble_spades(
-    seqs: Union[
+    reads: Union[
         SingleLanePerSamplePairedEndFastqDirFmt, SingleLanePerSampleSingleEndFastqDirFmt
     ],
     isolate: bool = False,
@@ -193,14 +193,14 @@ def assemble_spades(
     kwargs = {
         k: v
         for k, v in locals().items()
-        if k not in ["seqs", "uuid_type", "coassemble"]
+        if k not in ["reads", "uuid_type", "coassemble"]
     }
     common_args = _process_common_input_params(
         processing_func=_process_spades_arg, params=kwargs
     )
 
     return _assemble_spades(
-        seqs=seqs,
+        reads=reads,
         meta=meta,
         coassemble=coassemble,
         uuid_type=uuid_type,

--- a/q2_assembly/spades/tests/test_spades.py
+++ b/q2_assembly/spades/tests/test_spades.py
@@ -215,7 +215,7 @@ class TestSpades(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = _assemble_spades(
-            seqs=input,
+            reads=input,
             meta=False,
             uuid_type="shortuuid",
             common_args=self.test_params_list,
@@ -237,7 +237,7 @@ class TestSpades(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = _assemble_spades(
-            seqs=input,
+            reads=input,
             meta=False,
             coassemble=True,
             uuid_type="shortuuid",
@@ -265,7 +265,7 @@ class TestSpades(TestPluginBase):
         input = SingleLanePerSamplePairedEndFastqDirFmt(input_files, mode="r")
 
         obs = _assemble_spades(
-            seqs=input,
+            reads=input,
             meta=False,
             coassemble=True,
             uuid_type="shortuuid",
@@ -291,7 +291,7 @@ class TestSpades(TestPluginBase):
             NotImplementedError, 'SPAdes v3.15.2 in "meta" mode supports'
         ):
             _assemble_spades(
-                seqs=input,
+                reads=input,
                 meta=True,
                 uuid_type="shortuuid",
                 common_args=self.test_params_list,
@@ -307,7 +307,7 @@ class TestSpades(TestPluginBase):
             NotImplementedError, 'SPAdes v3.15.2 in "meta" mode supports'
         ):
             _assemble_spades(
-                seqs=input,
+                reads=input,
                 meta=True,
                 coassemble=True,
                 uuid_type="shortuuid",
@@ -325,7 +325,7 @@ class TestSpades(TestPluginBase):
             NotImplementedError, 'SPAdes v3.15.2 in "meta" mode supports'
         ):
             _assemble_spades(
-                seqs=input,
+                reads=input,
                 meta=True,
                 coassemble=True,
                 uuid_type="shortuuid",
@@ -340,7 +340,7 @@ class TestSpades(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         _ = assemble_spades(
-            seqs=input, meta=True, threads=14, k=[1, 2], cov_cutoff="off"
+            reads=input, meta=True, threads=14, k=[1, 2], cov_cutoff="off"
         )
         exp_args = [
             "--meta",
@@ -354,7 +354,7 @@ class TestSpades(TestPluginBase):
             "off",
         ]
         p1.assert_called_with(
-            seqs=input,
+            reads=input,
             meta=True,
             coassemble=False,
             uuid_type="shortuuid",
@@ -369,7 +369,7 @@ class TestSpades(TestPluginBase):
         input = SingleLanePerSampleSingleEndFastqDirFmt(input_files, mode="r")
 
         _assemble_spades(
-            seqs=input,
+            reads=input,
             meta=False,
             coassemble=False,
             uuid_type=uuid_type,


### PR DESCRIPTION
closes #48

- Changed all instances of "sequences" to "seqs".
- Changed all inputs that can be different sequence types to "seqs" and all inputs that are only reads to "reads".
- Changed all instances of "mapped_reads" to "alignment_maps".

closes #62 

- Changed spades memory and threads parameter description.