### PR TITLE
FIX: do not append _alignment_sorted to the BAM file path in the sort-alignment-maps action

### DIFF
--- a/q2_assembly/helpers/helpers.py
+++ b/q2_assembly/helpers/helpers.py
@@ -66,7 +66,7 @@ def sort_alignment_maps(
     out_dir = BAMDirFmt()
 
     for samp_name, fp in file_dict.items():
-        sorted_bam = os.path.join(str(out_dir), f"{samp_name}_alignment_sorted.bam")
+        sorted_bam = os.path.join(str(out_dir), f"{samp_name}.bam")
         run_command(["samtools", "sort", str(fp), "-o", sorted_bam], verbose=True)
 
     return out_dir

--- a/q2_assembly/tests/test_helpers.py
+++ b/q2_assembly/tests/test_helpers.py
@@ -124,9 +124,7 @@ class TestUtils(TestPluginBase):
             calls = []
             for map_fp in Path(tmp).glob("*.bam"):
                 samp_name = map_fp.stem
-                sorted_bam = os.path.join(
-                    str(out_dir), f"{samp_name}_alignment_sorted.bam"
-                )
+                sorted_bam = os.path.join(str(out_dir), f"{samp_name}.bam")
                 calls.append(
                     call(
                         ["samtools", "sort", str(map_fp), "-o", sorted_bam],


### PR DESCRIPTION
Currently, the sort-alignment-maps action appends the string `_alignment_sorted` to the file path of the `.bam` file. This behavior is undesirable because the map-reads action, which calls the sort-alignment-maps action, already appends the `_alignment` string, resulting in the string `_alignment` being added twice.

Current behavior (map-reads):

`<sample_name>` -> `<sample_name>_alignment_alignment_sorted.bam`

Desired behavior:

`<sample_name>` -> `<sample_name>_alignment_alignment_sorted.bam`

Adding `_sorted` at the end of the file path is unnecessary and would create an issue, e.g., if someone tries to sort an already sorted alignment map.

This PR removes the renaming from the sort-alignment-maps action, avoiding this issue entirely.